### PR TITLE
Add the functionality of "date1 to date2 by period"

### DIFF
--- a/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
@@ -11,7 +11,7 @@ case class DateInterval(startDate: LocalDate, endDate: LocalDate, step: Period) 
     if (0 <= idx && idx < length) {
       iterator.drop(idx).next
     } else {
-      throw new IndexOutOfBoundsException()
+      throw new IndexOutOfBoundsException(idx.toString)
     }
   }
   

--- a/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
@@ -1,0 +1,23 @@
+package jp.ne.opt.chronoscala
+
+import java.time.{LocalDate, Period}
+import jp.ne.opt.chronoscala.Imports.richLocalDate
+
+/**
+ * Represents an immutable date interval
+ */
+case class DateInterval(startDate: LocalDate, endDate: LocalDate, step: Period) extends Seq[LocalDate] {
+  def apply(idx: Int) = {
+    if (0 <= idx && idx < length) {
+      iterator.drop(idx).next
+    } else {
+      throw new IndexOutOfBoundsException()
+    }
+  }
+  
+  def iterator = Iterator.iterate(startDate)(_ + step).takeWhile(_ <= endDate)
+  
+  def length = iterator.length
+
+  def by(step: Period) = this.copy(step = step)
+}

--- a/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/DateInterval.scala
@@ -1,7 +1,7 @@
 package jp.ne.opt.chronoscala
 
 import java.time.{LocalDate, Period}
-import jp.ne.opt.chronoscala.Imports.richLocalDate
+import jp.ne.opt.chronoscala.Imports._
 
 /**
  * Represents an immutable date interval

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
@@ -10,4 +10,5 @@ class RichLocalDate(val underlying: LocalDate) extends AnyVal with Ordered[Local
 
   def compare(that: LocalDate): Int = underlying.compareTo(that)
 
+  def to(end: LocalDate): DateInterval = DateInterval(underlying, end, Period.ofDays(1))
 }


### PR DESCRIPTION
Just added a function that we use a lot, the usage is as below:
```
scala> val start = LocalDate.parse("2016-01-01")
start: java.time.LocalDate = 2016-01-01

scala> val end = LocalDate.parse("2016-01-05")
end: java.time.LocalDate = 2016-01-05

scala> start to end
res1: jp.ne.opt.chronoscala.DateInterval = DateInterval(2016-01-01, 2016-01-02, 2016-01-03, 2016-01-04, 2016-01-05)

scala> start to end by 2.days
res2: jp.ne.opt.chronoscala.DateInterval = DateInterval(2016-01-01, 2016-01-03, 2016-01-05)

scala> (start to end by 2.days).map(_ + 1.day)
res3: Seq[java.time.LocalDate] = List(2016-01-02, 2016-01-04, 2016-01-06)
```

If it's possible, please give me suggestions on how to make this merged. Thanks!