### PR TITLE
smarter parse for ZonedDateTime

### DIFF
--- a/src/main/scala/jp/ne/opt/chronoscala/ZonedDateTimeForwarder.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/ZonedDateTimeForwarder.scala
@@ -1,7 +1,9 @@
 package jp.ne.opt.chronoscala
 
-import java.time.format.DateTimeFormatter
-import java.time.{Clock, ZoneId, ZonedDateTime}
+import java.time.{LocalDateTime, Clock, LocalDate, ZoneId, ZonedDateTime}
+import java.time.format.{DateTimeFormatter, DateTimeParseException}
+
+import scala.util.Try
 
 trait ZonedDateTimeForwarder {
 
@@ -11,7 +13,13 @@ trait ZonedDateTimeForwarder {
 
   def now(zoneId: ZoneId) = ZonedDateTime.now(zoneId)
 
-  def parse(str: String) = ZonedDateTime.parse(str)
+  def parse(str: String) = Try {
+    ZonedDateTime.parse(str)
+  }.recover {
+    case e: DateTimeParseException => LocalDateTime.parse(str).atZone(ZoneId.systemDefault)
+  }.recover {
+    case e: DateTimeParseException => LocalDate.parse(str).atStartOfDay(ZoneId.systemDefault)
+  }.get
 
   def parse(str: String, formatter: DateTimeFormatter) = ZonedDateTime.parse(str, formatter)
 


### PR DESCRIPTION
Make `ZonedDateTime.parse()` able to parse `yyyy-MM-dd` and `yyyy-MM-ddTHH:mm:ss` formats without giving time or zone:
```
scala> import jp.ne.opt.chronoscala.Imports._
import jp.ne.opt.chronoscala.Imports._

scala> ZonedDateTime.parse("2016-12-13")
res0: java.time.ZonedDateTime = 2016-12-13T00:00+08:00[Asia/Taipei]

scala> ZonedDateTime.parse("2016-12-13T12:34:56")
res1: java.time.ZonedDateTime = 2016-12-13T12:34:56+08:00[Asia/Taipei]

scala> ZonedDateTime.parse("2016-12-13T12:34:56+09:00")
res2: java.time.ZonedDateTime = 2016-12-13T12:34:56+09:00
```

which is similar to JodaTime's behavior:
```
scala> import org.joda.time._ 
import org.joda.time._

scala> DateTime.parse("2016-12-13") 
res2: DateTime = 2016-12-13T00:00:00.000+08:00

scala> DateTime.parse("2016-12-13T12:34:56") 
res3: DateTime = 2016-12-13T12:34:56.000+08:00

scala> DateTime.parse("2016-12-13T12:34:56+09:00") 
res4: DateTime = 2016-12-13T12:34:56.000+09:00
```