### PR TITLE
add max and min functions for the Rich classes

### DIFF
--- a/src/main/scala/jp/ne/opt/chronoscala/RichInstant.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichInstant.scala
@@ -25,4 +25,7 @@ class RichInstant(val underlying: Instant) extends AnyVal with Ordered[Instant] 
 
   def compare(that: Instant): Int = underlying.compareTo(that)
 
+  def max(that: Instant): Instant = if (this > that) underlying else that
+
+  def min(that: Instant): Instant = if (this < that) underlying else that
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
@@ -10,5 +10,9 @@ class RichLocalDate(val underlying: LocalDate) extends AnyVal with Ordered[Local
 
   def compare(that: LocalDate): Int = underlying.compareTo(that)
 
+  def max(that: LocalDate): LocalDate = if (this > that) underlying else that
+
+  def min(that: LocalDate): LocalDate = if (this < that) underlying else that
+
   def to(end: LocalDate): DateInterval = DateInterval(underlying, end, Period.ofDays(1))
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalDateTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalDateTime.scala
@@ -23,4 +23,7 @@ class RichLocalDateTime(val underlying: LocalDateTime) extends AnyVal with Order
 
   def compare(that: LocalDateTime): Int = underlying.compareTo(that)
 
+  def max(that: LocalDateTime): LocalDateTime = if (this > that) underlying else that
+
+  def min(that: LocalDateTime): LocalDateTime = if (this < that) underlying else that
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalTime.scala
@@ -15,4 +15,7 @@ class RichLocalTime(val underlying: LocalTime) extends AnyVal with Ordered[Local
 
   def compare(that: LocalTime): Int = underlying.compareTo(that)
 
+  def max(that: LocalTime): LocalTime = if (this > that) underlying else that
+
+  def min(that: LocalTime): LocalTime = if (this < that) underlying else that
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichZonedDateTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichZonedDateTime.scala
@@ -25,4 +25,7 @@ class RichZonedDateTime(val underlying: ZonedDateTime) extends AnyVal with Order
 
   def compare(that: ZonedDateTime): Int = underlying.compareTo(that)
 
+  def max(that: ZonedDateTime): ZonedDateTime = if (this > that) underlying else that
+
+  def min(that: ZonedDateTime): ZonedDateTime = if (this < that) underlying else that
 }

--- a/src/test/scala/jp/ne/opt/chronoscala/Gens.scala
+++ b/src/test/scala/jp/ne/opt/chronoscala/Gens.scala
@@ -2,8 +2,7 @@ package jp.ne.opt.chronoscala
 
 import java.time.{Instant, ZonedDateTime}
 import java.util.TimeZone
-
-import org.scalacheck.Gen
+import org.scalacheck.{Arbitrary, Gen}
 
 trait Gens {
   def instantGen: Gen[Instant] = Gen.chooseNum(0L, Long.MaxValue).map(Instant.ofEpochMilli)
@@ -12,4 +11,6 @@ trait Gens {
     instant <- instantGen
     zoneId <- Gen.oneOf(TimeZone.getAvailableIDs.map(TimeZone.getTimeZone(_).toZoneId))
   } yield ZonedDateTime.ofInstant(instant, zoneId)
+
+  implicit val zonedDateTimeArbitrary = Arbitrary(zonedDateTimeGen)
 }

--- a/src/test/scala/jp/ne/opt/chronoscala/RichZonedDateTimeSpec.scala
+++ b/src/test/scala/jp/ne/opt/chronoscala/RichZonedDateTimeSpec.scala
@@ -6,16 +6,15 @@ import Imports._
 object RichZonedDateTimeSpec extends Properties("RichZonedDateTime") with Gens {
   import Prop.forAll
 
-  property("totally ordered") = forAll(for {
-    a <- zonedDateTimeGen
-    b <- zonedDateTimeGen
-    c <- zonedDateTimeGen
-  } yield (a, b, c)) {
-    case (a, b, c) =>
-      val antisymmetry = !(a <= b && b <= a) || a == b
-      val transitivity = !(a <= b && b <= c) || a <= c
-      val totality = a <= b || b <= a
+  property("totally ordered") = forAll { (a: ZonedDateTime, b: ZonedDateTime, c: ZonedDateTime) =>
+    val antisymmetry = !(a <= b && b <= a) || a == b
+    val transitivity = !(a <= b && b <= c) || a <= c
+    val totality = a <= b || b <= a
 
-      antisymmetry && transitivity && totality
+    antisymmetry && transitivity && totality
+  }
+
+  property("max and min") = forAll { (a: ZonedDateTime, b: ZonedDateTime) =>
+    (a max b) == (b max a) && (a min b) == (b min a) && (a min b) <= (a max b)
   }
 }


### PR DESCRIPTION
For
```
val a = LocalDate.parse("2016-11-13")
val b = LocalDate.parse("2016-12-13")
```
add the following usage:
```
scala> a max b
res5: java.time.LocalDate = 2016-12-13
```
which is equivalent to
```
scala> localDateOrdering.max(a, b)
res6: java.time.LocalDate = 2016-12-13
```
I added this feature for `Instant`, `LocalDate`, `LocalDateTime`, `LocalTime`, and `ZonedDateTime`. But I only wrote a test for `ZonedDateTime` for now. I also tried to add an `Arbitrary` for `ZonedDateTime` to make the testing code more simpler.

(The `a max b` syntax is also available in Scala's [RichInt](http://www.scala-lang.org/api/current/scala/runtime/RichInt.html#max(that:Int):Int))