### PR TITLE
add implicit conversion from String to ZoneId

### DIFF
--- a/src/main/scala/jp/ne/opt/chronoscala/Implicits.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/Implicits.scala
@@ -10,12 +10,14 @@ trait Implicits
   extends IntImplicits
   with DurationImplicits
   with TimeImplicits
+  with ZoneImplicits
   with OrderingImplicits
 
 trait NamespacedImplicits
   extends NamespacedIntImplicits
   with DurationImplicits
   with TimeImplicits
+  with ZoneImplicits
   with OrderingImplicits
 
 trait IntImplicits {
@@ -38,6 +40,10 @@ trait TimeImplicits {
   implicit def richLocalTime(t: LocalTime): RichLocalTime = new RichLocalTime(t)
   implicit def richLocalDate(t: LocalDate): RichLocalDate = new RichLocalDate(t)
   implicit def richInstant(i: Instant): RichInstant = new RichInstant(i)
+}
+
+trait ZoneImplicits {
+  implicit def stringToZoneId(s: String): ZoneId = ZoneId.of(s)
 }
 
 trait OrderingImplicits {


### PR DESCRIPTION
I found that every time I need to specify a time zone, I have to write something like
```
import java.time.ZoneId
LocalDate.parse("2016-12-18").atStartOfDay(ZoneId.of("Asia/Tokyo"))
```
How about adding an implicit conversion and we can write it as
```
LocalDate.parse("2016-12-18").atStartOfDay("Asia/Tokyo")
```