### PR TITLE
Add the shortcut functions format(pattern: String)

### DIFF
--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalDate.scala
@@ -1,6 +1,7 @@
 package jp.ne.opt.chronoscala
 
 import java.time.{Period, LocalDate}
+import java.time.format.DateTimeFormatter
 
 class RichLocalDate(val underlying: LocalDate) extends AnyVal with Ordered[LocalDate] {
 
@@ -11,4 +12,7 @@ class RichLocalDate(val underlying: LocalDate) extends AnyVal with Ordered[Local
   def compare(that: LocalDate): Int = underlying.compareTo(that)
 
   def to(end: LocalDate): DateInterval = DateInterval(underlying, end, Period.ofDays(1))
+
+  def format(pattern: String): String = underlying.format(DateTimeFormatter.ofPattern(pattern))
+
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalDateTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalDateTime.scala
@@ -1,6 +1,7 @@
 package jp.ne.opt.chronoscala
 
 import java.time.{Period, Duration, LocalDateTime}
+import java.time.format.DateTimeFormatter
 import java.time.temporal.{ChronoUnit, TemporalAmount}
 
 class RichLocalDateTime(val underlying: LocalDateTime) extends AnyVal with Ordered[LocalDateTime] {
@@ -22,5 +23,7 @@ class RichLocalDateTime(val underlying: LocalDateTime) extends AnyVal with Order
   def -(period: Period): LocalDateTime = underlying.minus(period)
 
   def compare(that: LocalDateTime): Int = underlying.compareTo(that)
+
+  def format(pattern: String): String = underlying.format(DateTimeFormatter.ofPattern(pattern))
 
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichLocalTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichLocalTime.scala
@@ -1,6 +1,7 @@
 package jp.ne.opt.chronoscala
 
 import java.time.{Duration, LocalTime}
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 class RichLocalTime(val underlying: LocalTime) extends AnyVal with Ordered[LocalTime] {
@@ -14,5 +15,7 @@ class RichLocalTime(val underlying: LocalTime) extends AnyVal with Ordered[Local
   def -(duration: Duration): LocalTime = underlying.minus(duration)
 
   def compare(that: LocalTime): Int = underlying.compareTo(that)
+
+  def format(pattern: String): String = underlying.format(DateTimeFormatter.ofPattern(pattern))
 
 }

--- a/src/main/scala/jp/ne/opt/chronoscala/RichZonedDateTime.scala
+++ b/src/main/scala/jp/ne/opt/chronoscala/RichZonedDateTime.scala
@@ -1,6 +1,7 @@
 package jp.ne.opt.chronoscala
 
 import java.time.{Period, Duration, ZonedDateTime}
+import java.time.format.DateTimeFormatter
 import java.time.temporal.{TemporalAmount, ChronoUnit}
 
 class RichZonedDateTime(val underlying: ZonedDateTime) extends AnyVal with Ordered[ZonedDateTime] {
@@ -24,5 +25,7 @@ class RichZonedDateTime(val underlying: ZonedDateTime) extends AnyVal with Order
   def to(end: ZonedDateTime): Interval = Interval(underlying.toInstant, end.toInstant)
 
   def compare(that: ZonedDateTime): Int = underlying.compareTo(that)
+
+  def format(pattern: String): String = underlying.format(DateTimeFormatter.ofPattern(pattern))
 
 }


### PR DESCRIPTION
Since https://github.com/opt-tech/chronoscala/pull/28 seems not going to be accepted, I'm afraid that this will be a similar one. (Sorry for repeating these kind of requests.)

The original motivation is come from JodaTime's `.toString(pattern: String)` method:
```
scala> import org.joda.time._ 
import org.joda.time._

scala> DateTime.now().toString("yyyy/MM/dd") 
res0: String = 2016/12/22
```

Hence I tried to make a similar feature for `java.time`'s `.format()` method:
```
scala> import jp.ne.opt.chronoscala.Imports._
import jp.ne.opt.chronoscala.Imports._

scala> LocalDate.now().format("yyyy/MM/dd")
res0: String = 2016/12/22
```

JodaTime also have `.toString(formatter: DateTimeFormatter)` and `.toString(pattern: String)` coexisting. I don't really feel confusing for this since I take it as a normal overloading. But I totally respect your concern. Do you think there's any possible way for this kind of feature be adopted? If there is, please tell me and I will modify it.